### PR TITLE
feat: Add remaining pure CPU instructions

### DIFF
--- a/src/cpu.c
+++ b/src/cpu.c
@@ -58,8 +58,11 @@ static void run_instruction(uint16_t instruction, struct cpu_status *status)
     switch (instruction & N1) {
         case 0x0000:  // System
             switch (instruction & MA) {
-                case 0x00E0:
+                case 0x00E0:  // Clear display
                     clear_display();
+                    break;
+                case 0x00EE:  // Return from subroutine
+                    pop(&s, &PC);
                     break;
                 default:
                     status->code = INVALID_INSTRUCTION;
@@ -69,6 +72,9 @@ static void run_instruction(uint16_t instruction, struct cpu_status *status)
         case 0x1000:  // Jump
             PC = instruction & MA;
             break;
+        case 0x2000:  // Call subroutine
+            push(&s, PC);
+            PC = instruction & MA;
         case 0x6000:  // Set variable register
             V[(instruction & N2) >> 8] = instruction & B2;
             break;

--- a/src/cpu.c
+++ b/src/cpu.c
@@ -72,6 +72,10 @@ static void run_instruction(uint16_t instruction, struct cpu_status *status)
         case 0x1000:  // Jump
             PC = instruction & MA;
             break;
+        case 0xB000:  // Jump with offset
+            PC = (instruction & MA) + V[0x0];
+            // TODO: Add configurable option to use offset of specific register.
+            break;
         case 0x2000:  // Call subroutine
             push(&s, PC);
             PC = instruction & MA;

--- a/src/cpu.c
+++ b/src/cpu.c
@@ -174,6 +174,11 @@ static void run_instruction(uint16_t instruction, struct cpu_status *status)
                         V[0xF] = 1;
                     }
                     break;
+                case 0x0009:  // Set index register to character
+                {
+                    uint8_t character = V[(instruction & N2) >> 8] & 0x0F;
+                    I = FONT_START + character * 5;
+                } break;
                 default:
                     status->code = INVALID_INSTRUCTION;
                     status->instruction = instruction;

--- a/src/cpu.c
+++ b/src/cpu.c
@@ -64,7 +64,7 @@ static void run_instruction(uint16_t instruction, struct cpu_status *status)
                 case 0x00EE:  // Return from subroutine
                     pop(&s, &PC);
                     break;
-                default:
+                default:  // Call machine code routine
                     status->code = INVALID_INSTRUCTION;
                     status->instruction = instruction;
             }

--- a/src/cpu.c
+++ b/src/cpu.c
@@ -101,6 +101,50 @@ static void run_instruction(uint16_t instruction, struct cpu_status *status)
         case 0x7000:  // Add to variable register
             V[(instruction & N2) >> 8] += instruction & B2;
             break;
+        case 0x8000:  // Logic and arithmetic
+        {
+            uint8_t *VX = &V[(instruction & N2) >> 8];
+            uint8_t *VY = &V[(instruction & N3) >> 4];
+            switch (instruction & N4) {
+                case 0x000:  // Set
+                    V[(instruction & N2) >> 8] = V[(instruction & N3) >> 4];
+                    break;
+                case 0x004:  // Add
+                    *VX = *VX + *VY;
+                    V[0xF] = *VX <= *VY;
+                    break;
+                case 0x005:  // Subtract Y from X
+                    V[0xF] = *VY > *VX;
+                    *VX = *VY - *VX;
+                    break;
+                case 0x007:  // Subtract X from Y
+                    V[0xF] = *VX > *VY;
+                    *VX = *VX - *VY;
+                    break;
+                case 0x00E:  // Shift left
+                    V[0xF] = (*VX & 0x80) >> 7;
+                    *VX = *VX << 1;
+                    // TODO: Add configurable option to move VY into VX.
+                    break;
+                case 0x006:  // Shift right
+                    V[0xF] = *VX & 0x01;
+                    *VX = *VX >> 1;
+                    // TODO: Add configurable option to move VY into VX.
+                    break;
+                case 0x002:  // AND
+                    *VX = *VX & *VY;
+                    break;
+                case 0x001:  // OR
+                    *VX = *VX | *VY;
+                    break;
+                case 0x003:  // XOR
+                    *VX = *VX ^ *VY;
+                    break;
+                default:
+                    status->code = INVALID_INSTRUCTION;
+                    status->instruction = instruction;
+            }
+        }
         case 0xA000:  // Set index register
             I = instruction & MA;
             break;

--- a/src/cpu.c
+++ b/src/cpu.c
@@ -163,6 +163,22 @@ static void run_instruction(uint16_t instruction, struct cpu_status *status)
         case 0xC000:  // Random
             V[(instruction & N2) >> 8] = (uint8_t)rand() & (instruction & B2);
             break;
+        case 0xF000:  // Misc.
+            switch (instruction & N4) {
+                case 0x000E:  // Add to index register
+                    I += V[(instruction & N2) >> 8];
+                    // Manually handle overflow, as the variable is a uint16,
+                    // but the memory space of the system is 12 bits long.
+                    if (I > 0xFFF) {
+                        I = I % 0xFFF - 1;
+                        V[0xF] = 1;
+                    }
+                    break;
+                default:
+                    status->code = INVALID_INSTRUCTION;
+                    status->instruction = instruction;
+            }
+            break;
         default:
             status->code = UNKNOWN_INSTRUCTION;
             status->instruction = instruction;

--- a/src/cpu.c
+++ b/src/cpu.c
@@ -75,6 +75,26 @@ static void run_instruction(uint16_t instruction, struct cpu_status *status)
         case 0x2000:  // Call subroutine
             push(&s, PC);
             PC = instruction & MA;
+        case 0x3000:  // Skip if variable equal to constant
+            if (V[(instruction & N2) >> 8] == (instruction & B2)) {
+                PC += 2;
+            }
+            break;
+        case 0x4000:  // Skip if variable not equal to constant
+            if (V[(instruction & N2) >> 8] != (instruction & B2)) {
+                PC += 2;
+            }
+            break;
+        case 0x5000:  // Skip if variable equal to variable
+            if (V[(instruction & N2) >> 8] == V[(instruction & N3) >> 4]) {
+                PC += 2;
+            }
+            break;
+        case 0x9000:  // Skip if variable not equal to variable
+            if (V[(instruction & N2) >> 8] != V[(instruction & N3) >> 4]) {
+                PC += 2;
+            }
+            break;
         case 0x6000:  // Set variable register
             V[(instruction & N2) >> 8] = instruction & B2;
             break;

--- a/src/cpu.c
+++ b/src/cpu.c
@@ -179,6 +179,23 @@ static void run_instruction(uint16_t instruction, struct cpu_status *status)
                     uint8_t character = V[(instruction & N2) >> 8] & 0x0F;
                     I = FONT_START + character * 5;
                 } break;
+                case 0x0003:  // Convert to decimal
+                {
+                    uint8_t *memory = get_memory_pointer(I);
+                    uint8_t num = V[(instruction & N2) >> 8];
+                    // Extract the digits least significant to most.
+                    uint8_t digits[3];
+                    uint8_t i = 0;
+                    do {
+                        digits[i++] = num % 10;
+                        num /= 10;
+                    } while (num != 0);
+                    // Insert the digits most significant to least.
+                    uint8_t j = 0;
+                    do {
+                        memory[j++] = digits[--i];
+                    } while (i != 0);
+                } break;
                 default:
                     status->code = INVALID_INSTRUCTION;
                     status->instruction = instruction;

--- a/src/cpu.c
+++ b/src/cpu.c
@@ -196,6 +196,24 @@ static void run_instruction(uint16_t instruction, struct cpu_status *status)
                         memory[j++] = digits[--i];
                     } while (i != 0);
                 } break;
+                case 0x0055:  // Store memory
+                {
+                    uint8_t *memory = get_memory_pointer(I);
+                    for (uint8_t i = 0; i <= (instruction & N2) >> 8; i++) {
+                        memory[i] = V[i];
+                        // TODO: Add configurable option to increment I.
+                    }
+                    break;
+                }
+                case 0x0065:  // Load memory
+                {
+                    uint8_t *memory = get_memory_pointer(I);
+                    for (uint8_t i = 0; i <= (instruction & N2) >> 8; i++) {
+                        V[i] = memory[i];
+                        // TODO: Add configurable option to increment I.
+                    }
+                    break;
+                }
                 default:
                     status->code = INVALID_INSTRUCTION;
                     status->instruction = instruction;

--- a/src/cpu.c
+++ b/src/cpu.c
@@ -164,8 +164,8 @@ static void run_instruction(uint16_t instruction, struct cpu_status *status)
             V[(instruction & N2) >> 8] = (uint8_t)rand() & (instruction & B2);
             break;
         case 0xF000:  // Misc.
-            switch (instruction & N4) {
-                case 0x000E:  // Add to index register
+            switch (instruction & B2) {
+                case 0x001E:  // Add to index register
                     I += V[(instruction & N2) >> 8];
                     // Manually handle overflow, as the variable is a uint16,
                     // but the memory space of the system is 12 bits long.
@@ -174,12 +174,12 @@ static void run_instruction(uint16_t instruction, struct cpu_status *status)
                         V[0xF] = 1;
                     }
                     break;
-                case 0x0009:  // Set index register to character
+                case 0x0029:  // Set index register to character
                 {
                     uint8_t character = V[(instruction & N2) >> 8] & 0x0F;
                     I = FONT_START + character * 5;
                 } break;
-                case 0x0003:  // Convert to decimal
+                case 0x0033:  // Convert to decimal
                 {
                     uint8_t *memory = get_memory_pointer(I);
                     uint8_t num = V[(instruction & N2) >> 8];

--- a/src/cpu.c
+++ b/src/cpu.c
@@ -5,6 +5,7 @@
 #include <stdlib.h>
 
 #include "display.h"
+#include "macros.h"
 #include "memory.h"
 #include "stack.h"
 
@@ -158,6 +159,9 @@ static void run_instruction(uint16_t instruction, struct cpu_status *status)
                 V[(instruction & N3) >> 4],
                 instruction & N4,
                 get_memory_pointer(I));
+            break;
+        case 0xC000:  // Random
+            V[(instruction & N2) >> 8] = (uint8_t)rand() & (instruction & B2);
             break;
         default:
             status->code = UNKNOWN_INSTRUCTION;

--- a/tests/test_cpu.c
+++ b/tests/test_cpu.c
@@ -394,6 +394,22 @@ void test_add_index_updates_index_register_with_carry()
     TEST_ASSERT_TRUE(get_variable_registers()[0xF]);
 }
 
+// 0xFX29
+void test_font_character()
+{
+    struct cpu_status status;
+
+    debug_run_instruction(0x6001);
+    status = debug_run_instruction(0xF029);
+    TEST_ASSERT_EQUAL_UINT8(SUCCESS, status.code);
+    TEST_ASSERT_EQUAL_INT16(FONT_START + 5, get_index_register());
+
+    debug_run_instruction(0x6004);
+    status = debug_run_instruction(0xF029);
+    TEST_ASSERT_EQUAL_UINT8(SUCCESS, status.code);
+    TEST_ASSERT_EQUAL_INT16(FONT_START + 20, get_index_register());
+}
+
 // 0xDXYN
 void test_draw_renders_sprite()
 {
@@ -504,6 +520,7 @@ int main()
     RUN_TEST(test_set_index_updates_index_register);
     RUN_TEST(test_add_index_updates_index_register);
     RUN_TEST(test_add_index_updates_index_register_with_carry);
+    RUN_TEST(test_font_character);
     RUN_TEST(test_draw_renders_sprite);
     RUN_TEST(test_clear_display_clears_display);
     RUN_TEST(test_read_instruction_reads_and_moves_pc);

--- a/tests/test_cpu.c
+++ b/tests/test_cpu.c
@@ -93,6 +93,73 @@ void test_jump_updates_program_counter()
     TEST_ASSERT_EQUAL_INT16(0xFFF, get_program_counter());
 }
 
+// 0x3XNN
+void test_skip_if_variable_equal_constant()
+{
+    struct cpu_status status;
+
+    // False
+    status = debug_run_instruction(0x3001);
+    TEST_ASSERT_EQUAL_UINT8(SUCCESS, status.code);
+    TEST_ASSERT_EQUAL_INT16(0x200, get_program_counter());
+
+    // True
+    status = debug_run_instruction(0x3000);
+    TEST_ASSERT_EQUAL_UINT8(SUCCESS, status.code);
+    TEST_ASSERT_EQUAL_INT16(0x202, get_program_counter());
+}
+
+// 0x4XNN
+void test_skip_if_variable_not_equal_constant()
+{
+    struct cpu_status status;
+
+    // False
+    status = debug_run_instruction(0x4000);
+    TEST_ASSERT_EQUAL_UINT8(SUCCESS, status.code);
+    TEST_ASSERT_EQUAL_INT16(0x200, get_program_counter());
+
+    // True
+    status = debug_run_instruction(0x4001);
+    TEST_ASSERT_EQUAL_UINT8(SUCCESS, status.code);
+    TEST_ASSERT_EQUAL_INT16(0x202, get_program_counter());
+}
+
+// 0x5XY0
+void test_skip_if_variable_equal_variable()
+{
+    struct cpu_status status;
+
+    // False
+    debug_run_instruction(0x6101);           // Set V1 to 1.
+    status = debug_run_instruction(0x5010);  // Compare V0 (0) to V1 (1).
+    TEST_ASSERT_EQUAL_UINT8(SUCCESS, status.code);
+    TEST_ASSERT_EQUAL_INT16(0x200, get_program_counter());
+
+    // True
+    debug_run_instruction(0x6100);           // Set V1 to 0.
+    status = debug_run_instruction(0x5010);  // Compare V0 (0) to V1 (0).
+    TEST_ASSERT_EQUAL_UINT8(SUCCESS, status.code);
+    TEST_ASSERT_EQUAL_INT16(0x202, get_program_counter());
+}
+
+// 0x9XY0
+void test_skip_if_variable_not_equal_variable()
+{
+    struct cpu_status status;
+
+    // False
+    status = debug_run_instruction(0x9010);  // Compare V0 (0) to V1 (0).
+    TEST_ASSERT_EQUAL_UINT8(SUCCESS, status.code);
+    TEST_ASSERT_EQUAL_INT16(0x200, get_program_counter());
+
+    // True
+    debug_run_instruction(0x6101);           // Set V1 to 1.
+    status = debug_run_instruction(0x9010);  // Compare V0 (0) to V1 (1).
+    TEST_ASSERT_EQUAL_UINT8(SUCCESS, status.code);
+    TEST_ASSERT_EQUAL_INT16(0x202, get_program_counter());
+}
+
 // 0xANNN
 void test_set_index_updates_index_register()
 {
@@ -191,6 +258,10 @@ int main()
     RUN_TEST(test_set_updates_variable_registers);
     RUN_TEST(test_add_updates_variable_registers);
     RUN_TEST(test_jump_updates_program_counter);
+    RUN_TEST(test_skip_if_variable_equal_constant);
+    RUN_TEST(test_skip_if_variable_not_equal_constant);
+    RUN_TEST(test_skip_if_variable_equal_variable);
+    RUN_TEST(test_skip_if_variable_not_equal_variable);
     RUN_TEST(test_set_index_updates_index_register);
     RUN_TEST(test_draw_renders_sprite);
     RUN_TEST(test_clear_display_clears_display);

--- a/tests/test_cpu.c
+++ b/tests/test_cpu.c
@@ -367,6 +367,33 @@ void test_set_index_updates_index_register()
     TEST_ASSERT_EQUAL_INT16(0x300, get_index_register());
 }
 
+// 0xFX1E
+void test_add_index_updates_index_register()
+{
+    struct cpu_status status;
+
+    debug_run_instruction(0x6002);
+    debug_run_instruction(0xA300);
+
+    status = debug_run_instruction(0xF01E);
+    TEST_ASSERT_EQUAL_UINT8(SUCCESS, status.code);
+    TEST_ASSERT_EQUAL_INT16(0x302, get_index_register());
+    TEST_ASSERT_FALSE(get_variable_registers()[0xF]);
+}
+
+void test_add_index_updates_index_register_with_carry()
+{
+    struct cpu_status status;
+
+    debug_run_instruction(0x6002);
+    debug_run_instruction(0xAFFF);
+
+    status = debug_run_instruction(0xF01E);
+    TEST_ASSERT_EQUAL_UINT8(SUCCESS, status.code);
+    TEST_ASSERT_EQUAL_INT16(0x001, get_index_register());
+    TEST_ASSERT_TRUE(get_variable_registers()[0xF]);
+}
+
 // 0xDXYN
 void test_draw_renders_sprite()
 {
@@ -475,6 +502,8 @@ int main()
     RUN_TEST(test_skip_if_variable_equal_variable);
     RUN_TEST(test_skip_if_variable_not_equal_variable);
     RUN_TEST(test_set_index_updates_index_register);
+    RUN_TEST(test_add_index_updates_index_register);
+    RUN_TEST(test_add_index_updates_index_register_with_carry);
     RUN_TEST(test_draw_renders_sprite);
     RUN_TEST(test_clear_display_clears_display);
     RUN_TEST(test_read_instruction_reads_and_moves_pc);

--- a/tests/test_cpu.c
+++ b/tests/test_cpu.c
@@ -79,6 +79,188 @@ void test_add_updates_variable_registers()
     TEST_ASSERT_EQUAL_INT8(0x03, get_variable_registers()[3]);
 }
 
+// 0x8XY0
+void test_set_vx_to_vy()
+{
+    struct cpu_status status;
+
+    debug_run_instruction(0x6101);
+
+    status = debug_run_instruction(0x8010);
+    TEST_ASSERT_EQUAL_UINT8(SUCCESS, status.code);
+    TEST_ASSERT_EQUAL_UINT8(0x01, get_variable_registers()[0x0]);
+}
+
+// 0x8XY4
+void test_add_vy_to_vx()
+{
+    struct cpu_status status;
+
+    debug_run_instruction(0x6001);
+    debug_run_instruction(0x6102);
+
+    status = debug_run_instruction(0x8014);
+    TEST_ASSERT_EQUAL_UINT8(SUCCESS, status.code);
+    TEST_ASSERT_EQUAL_UINT8(0x03, get_variable_registers()[0x0]);
+    TEST_ASSERT_FALSE(get_variable_registers()[0xF]);
+}
+
+void test_add_vy_to_vx_with_carry()
+{
+    struct cpu_status status;
+
+    debug_run_instruction(0x60FF);
+    debug_run_instruction(0x6102);
+
+    status = debug_run_instruction(0x8014);
+    TEST_ASSERT_EQUAL_UINT8(SUCCESS, status.code);
+    TEST_ASSERT_EQUAL_UINT8(0x01, get_variable_registers()[0x0]);
+    TEST_ASSERT_TRUE(get_variable_registers()[0xF]);
+}
+
+// 0x8XY5
+void test_subtract_vy_from_vx()
+{
+    struct cpu_status status;
+
+    debug_run_instruction(0x6002);
+    debug_run_instruction(0x6101);
+
+    status = debug_run_instruction(0x8015);
+    TEST_ASSERT_EQUAL_UINT8(SUCCESS, status.code);
+    TEST_ASSERT_EQUAL_UINT8(0xFF, get_variable_registers()[0x0]);
+    TEST_ASSERT_FALSE(get_variable_registers()[0xF]);
+}
+
+void test_subtract_vy_from_vx_with_carry()
+{
+    struct cpu_status status;
+
+    debug_run_instruction(0x6001);
+    debug_run_instruction(0x6102);
+
+    status = debug_run_instruction(0x8015);
+    TEST_ASSERT_EQUAL_UINT8(SUCCESS, status.code);
+    TEST_ASSERT_EQUAL_UINT8(0x01, get_variable_registers()[0x0]);
+    TEST_ASSERT_TRUE(get_variable_registers()[0xF]);
+}
+
+// 0x8XY7
+void test_subtract_vx_from_vy()
+{
+    struct cpu_status status;
+
+    debug_run_instruction(0x6001);
+    debug_run_instruction(0x6102);
+
+    status = debug_run_instruction(0x8017);
+    TEST_ASSERT_EQUAL_UINT8(SUCCESS, status.code);
+    TEST_ASSERT_EQUAL_UINT8(0xFF, get_variable_registers()[0x0]);
+    TEST_ASSERT_FALSE(get_variable_registers()[0xF]);
+}
+
+void test_subtract_vx_from_vy_with_carry()
+{
+    struct cpu_status status;
+
+    debug_run_instruction(0x6002);
+    debug_run_instruction(0x6101);
+
+    status = debug_run_instruction(0x8017);
+    TEST_ASSERT_EQUAL_UINT8(SUCCESS, status.code);
+    TEST_ASSERT_EQUAL_UINT8(0x01, get_variable_registers()[0x0]);
+    TEST_ASSERT_TRUE(get_variable_registers()[0xF]);
+}
+
+// 0x8XYE
+void test_shift_left()
+{
+    struct cpu_status status;
+
+    debug_run_instruction(0x6003);  // Set V0 to 0b00000011
+
+    status = debug_run_instruction(0x800E);
+    TEST_ASSERT_EQUAL_UINT8(SUCCESS, status.code);
+    TEST_ASSERT_EQUAL_UINT8(0b00000110, get_variable_registers()[0x0]);
+    TEST_ASSERT_FALSE(get_variable_registers()[0xF]);
+}
+
+void test_shift_left_with_carry()
+{
+    struct cpu_status status;
+
+    debug_run_instruction(0x60C0);  // Set V0 to 0b11000000
+
+    status = debug_run_instruction(0x800E);
+    TEST_ASSERT_EQUAL_UINT8(SUCCESS, status.code);
+    TEST_ASSERT_EQUAL_UINT8(0b10000000, get_variable_registers()[0x0]);
+    TEST_ASSERT_TRUE(get_variable_registers()[0xF]);
+}
+
+// 0x8XY6
+void test_shift_right()
+{
+    struct cpu_status status;
+
+    debug_run_instruction(0x60C0);  // Set V0 to 0b11000000
+
+    status = debug_run_instruction(0x8006);
+    TEST_ASSERT_EQUAL_UINT8(SUCCESS, status.code);
+    TEST_ASSERT_EQUAL_UINT8(0b01100000, get_variable_registers()[0x0]);
+    TEST_ASSERT_FALSE(get_variable_registers()[0xF]);
+}
+
+void test_shift_right_with_carry()
+{
+    struct cpu_status status;
+
+    debug_run_instruction(0x6003);  // Set V0 to 0b00000011
+
+    status = debug_run_instruction(0x8006);
+    TEST_ASSERT_EQUAL_UINT8(SUCCESS, status.code);
+    TEST_ASSERT_EQUAL_UINT8(0b00000001, get_variable_registers()[0x0]);
+    TEST_ASSERT_TRUE(get_variable_registers()[0xF]);
+}
+
+// 0x8XY2
+void test_and()
+{
+    struct cpu_status status;
+
+    debug_run_instruction(0x60AC);  // Set V0 to 0b10101100
+    debug_run_instruction(0x6156);  // Set V1 to 0b01010110
+
+    status = debug_run_instruction(0x8012);
+    TEST_ASSERT_EQUAL_UINT8(SUCCESS, status.code);
+    TEST_ASSERT_EQUAL_UINT8(0b00000100, get_variable_registers()[0x0]);
+}
+
+// 0x8XY1
+void test_or()
+{
+    struct cpu_status status;
+
+    debug_run_instruction(0x60AC);  // Set V0 to 0b10101100
+    debug_run_instruction(0x6156);  // Set V1 to 0b01010110
+
+    status = debug_run_instruction(0x8011);
+    TEST_ASSERT_EQUAL_UINT8(SUCCESS, status.code);
+    TEST_ASSERT_EQUAL_UINT8(0b11111110, get_variable_registers()[0x0]);
+}
+
+// 0x8XY3
+void test_xor()
+{
+    struct cpu_status status;
+
+    debug_run_instruction(0x60AC);  // Set V0 to 0b10101100
+    debug_run_instruction(0x6156);  // Set V1 to 0b01010110
+
+    status = debug_run_instruction(0x8013);
+    TEST_ASSERT_EQUAL_UINT8(SUCCESS, status.code);
+    TEST_ASSERT_EQUAL_UINT8(0b11111010, get_variable_registers()[0x0]);
+}
+
 // 0x1NNN
 void test_jump_updates_program_counter()
 {
@@ -257,6 +439,20 @@ int main()
     RUN_TEST(test_machine_language_routine_is_error);
     RUN_TEST(test_set_updates_variable_registers);
     RUN_TEST(test_add_updates_variable_registers);
+    RUN_TEST(test_set_vx_to_vy);
+    RUN_TEST(test_add_vy_to_vx);
+    RUN_TEST(test_add_vy_to_vx_with_carry);
+    RUN_TEST(test_subtract_vy_from_vx);
+    RUN_TEST(test_subtract_vy_from_vx_with_carry);
+    RUN_TEST(test_subtract_vx_from_vy);
+    RUN_TEST(test_subtract_vx_from_vy_with_carry);
+    RUN_TEST(test_shift_left);
+    RUN_TEST(test_shift_left_with_carry);
+    RUN_TEST(test_shift_right);
+    RUN_TEST(test_shift_right_with_carry);
+    RUN_TEST(test_and);
+    RUN_TEST(test_or);
+    RUN_TEST(test_xor);
     RUN_TEST(test_jump_updates_program_counter);
     RUN_TEST(test_skip_if_variable_equal_constant);
     RUN_TEST(test_skip_if_variable_not_equal_constant);

--- a/tests/test_cpu.c
+++ b/tests/test_cpu.c
@@ -275,6 +275,21 @@ void test_jump_updates_program_counter()
     TEST_ASSERT_EQUAL_INT16(0xFFF, get_program_counter());
 }
 
+// 0xBNNN
+void test_jump_with_offset_updates_program_counter()
+{
+    struct cpu_status status;
+
+    status = debug_run_instruction(0xB100);
+    TEST_ASSERT_EQUAL_UINT8(SUCCESS, status.code);
+    TEST_ASSERT_EQUAL_INT16(0x100, get_program_counter());
+
+    debug_run_instruction(0x600F);
+    status = debug_run_instruction(0xB100);
+    TEST_ASSERT_EQUAL_UINT8(SUCCESS, status.code);
+    TEST_ASSERT_EQUAL_INT16(0x10F, get_program_counter());
+}
+
 // 0x3XNN
 void test_skip_if_variable_equal_constant()
 {
@@ -454,6 +469,7 @@ int main()
     RUN_TEST(test_or);
     RUN_TEST(test_xor);
     RUN_TEST(test_jump_updates_program_counter);
+    RUN_TEST(test_jump_with_offset_updates_program_counter);
     RUN_TEST(test_skip_if_variable_equal_constant);
     RUN_TEST(test_skip_if_variable_not_equal_constant);
     RUN_TEST(test_skip_if_variable_equal_variable);

--- a/tests/test_cpu.c
+++ b/tests/test_cpu.c
@@ -476,6 +476,34 @@ void test_clear_display_clears_display()
     }
 }
 
+// 0xFX33
+void test_decimal_conversion()
+{
+    struct cpu_status status;
+    uint8_t *memory = get_memory_pointer(get_index_register());
+
+    debug_run_instruction(0x6001);  // Set V0 to 1.
+
+    status = debug_run_instruction(0xF033);
+    TEST_ASSERT_EQUAL_UINT8(SUCCESS, status.code);
+    TEST_ASSERT_EQUAL_UINT8(1, memory[0]);
+
+    debug_run_instruction(0x600F);  // Set V0 to 15.
+
+    status = debug_run_instruction(0xF033);
+    TEST_ASSERT_EQUAL_UINT8(SUCCESS, status.code);
+    TEST_ASSERT_EQUAL_UINT8(1, memory[0]);
+    TEST_ASSERT_EQUAL_UINT8(5, memory[1]);
+
+    debug_run_instruction(0x609C);  // Set V0 to 156.
+
+    status = debug_run_instruction(0xF033);
+    TEST_ASSERT_EQUAL_UINT8(SUCCESS, status.code);
+    TEST_ASSERT_EQUAL_UINT8(1, memory[0]);
+    TEST_ASSERT_EQUAL_UINT8(5, memory[1]);
+    TEST_ASSERT_EQUAL_UINT8(6, memory[2]);
+}
+
 // MARK: CPU cycling
 
 void test_read_instruction_reads_and_moves_pc()
@@ -523,6 +551,7 @@ int main()
     RUN_TEST(test_font_character);
     RUN_TEST(test_draw_renders_sprite);
     RUN_TEST(test_clear_display_clears_display);
+    RUN_TEST(test_decimal_conversion);
     RUN_TEST(test_read_instruction_reads_and_moves_pc);
     RUN_TEST(test_run_cycle_reads_and_executes_instruction);
     return UNITY_END();


### PR DESCRIPTION
Adds the remaining instructions that are resolved and dependent purely on the CPU or the memory.

Essentially, this finishes up everything except key presses and timer interactions, as those have no logic implemented for their actual behavior, so there would be no way to test them, whether manual or automated.